### PR TITLE
Cli typo fix and gitignore additions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ rdoc
 test/tmp
 tmp
 test/sandbox
+.sass-cache

--- a/generators/application/gitignore
+++ b/generators/application/gitignore
@@ -1,2 +1,3 @@
+.sass-cache/
 tmp/
 site/

--- a/lib/iridium/cli.rb
+++ b/lib/iridium/cli.rb
@@ -24,7 +24,7 @@ module Iridium
 
     desc "server", "start a development server"
     def server
-      Iridum.load!
+      Iridium.load!
       Iridium::DevServer.new.start
     end
 


### PR DESCRIPTION
Fixed the issue where running bundle exec iridium server would fail because of a typo.

Also added sass-cache to git ignore.
