### PR TITLE
Handlebars in subfolders

### DIFF
--- a/lib/iridium/Assetfile
+++ b/lib/iridium/Assetfile
@@ -8,7 +8,10 @@ input app.app_path do
   end
 
   match "**/*.{hbs,handlebars}" do
-    handlebars
+    handlebars  :key_name_proc => proc { |input|
+        templates_path = 'javascripts/templates/'
+        input.path.chomp(File.extname(input.path)).gsub(/#{templates_path}/, '')
+    }
   end
 
   match "**/*.coffee" do

--- a/lib/iridium/Assetfile
+++ b/lib/iridium/Assetfile
@@ -10,7 +10,12 @@ input app.app_path do
   match "**/*.{hbs,handlebars}" do
     handlebars  :key_name_proc => proc { |input|
         templates_path = 'javascripts/templates/'
-        input.path.chomp(File.extname(input.path)).gsub(/#{templates_path}/, '')
+
+        if input.path.start_with?(templates_path)
+          input.path.chomp(File.extname(input.path)).gsub(/#{templates_path}/, '')
+        else
+          File.basename(input.path, File.extname(input.path))
+        end
     }
   end
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -146,7 +146,7 @@ class PipelineTest < MiniTest::Unit::TestCase
     assert_includes content, %Q{color: #4d926f;}
   end
 
-  def tests_compiles_handle_bars_into_js_file
+  def tests_compiles_handle_bars_into_js_file_not_in_templates_folder
     create_file "app/javascripts/home.handlebars", "{{#name}}"
 
     compile ; assert_file "site/application.js"
@@ -154,9 +154,10 @@ class PipelineTest < MiniTest::Unit::TestCase
     content = read "site/application.js"
 
     assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['home']"
   end
 
-  def tests_compiles_hbs_into_js_file
+  def tests_compiles_hbs_into_js_file_not_in_templates_folder
     create_file "app/javascripts/home.hbs", "{{#name}}"
 
     compile ; assert_file "site/application.js"
@@ -164,6 +165,74 @@ class PipelineTest < MiniTest::Unit::TestCase
     content = read "site/application.js"
 
     assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['home']"
+  end
+
+  def tests_compiles_handle_bars_into_js_file
+    create_file "app/javascripts/templates/home.handlebars", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['home']"
+  end
+
+  def tests_compiles_hbs_into_js_file
+    create_file "app/javascripts/templates/home.hbs", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['home']"
+  end
+
+  def tests_compiles_handle_bars_into_js_file_including_subfolder
+    create_file "app/javascripts/templates/subfolder/home.handlebars", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['subfolder/home']"
+  end
+
+  def tests_compiles_hbs_into_js_file_including_subfolder
+    create_file "app/javascripts/templates/subfolder/home.hbs", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['subfolder/home']"
+  end
+
+
+  def tests_compiles_handle_bars_into_js_file_including_multiple_subfolders
+    create_file "app/javascripts/templates/multiple/subfolders/home.handlebars", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['multiple/subfolders/home']"
+  end
+
+  def tests_compiles_hbs_into_js_file_including_mulitple_subfolders
+    create_file "app/javascripts/templates/multiple/subfolders/home.hbs", "{{#name}}"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, "{{#name}}"
+    assert_includes content, "Ember.TEMPLATES['multiple/subfolders/home']"
   end
 
   def test_concats_vendor_css_before_app_css


### PR DESCRIPTION
We are using subfolders with out templates to help organize the files for development (similar to that which ember-rails provides). This allows us to group a set of templates for a given set of functionality. Consider the following example layout:

```
- app
  - javascripts
    - templates
      - account
        - edit.handlebars
        - new.handlebars
        - show.handlebars
      - person
        - edit.handlebars
        - new.handlebars
        - show.handlebars
```

In the current implementation, the handlebars pipeline filter will find all of these handlebars files and will process them as we would expect… sort of. The standard handlebars filter will take the filename, sans extension, as the key for the Ember.TEMPLATES hash, thus causing key name collisions in this example. The example above would create:

```
Ember.TEMPLATES['edit']...
Ember.TEMPLATES['new']...
Ember.TEMPLATES['show']...
```

I have modified the Assetfile that Iridium operates on to take into account any subfolders when generating the key name for the Ember.TEMPLATES hash. If the handlebars file being processed exists in the standard templates location (app/javascripts/templates), any subfolders past the templates folder will be taken into account when generating the key for the Ember.TEMPLATES hash. If the handlebars file being processed exists somewhere other than the standard location, the default behavior is used. Now, the example above creates:

```
Ember.TEMPLATES['account/edit']...
Ember.TEMPLATES['account/new']...
Ember.TEMPLATES['account/show']...
Ember.TEMPLATES['person/edit']...
Ember.TEMPLATES['person/new']...
Ember.TEMPLATES['person/show']...
```

Unit tests have also been added that test when the handlebars file is found in the standard location, a non-standard location and when subfolders are present.

Thanks!
