### PR TITLE
For non production env use minispade string modules in order to preserve...

### DIFF
--- a/lib/iridium/Assetfile
+++ b/lib/iridium/Assetfile
@@ -49,7 +49,7 @@ input app.app_path do
   # app/javascripts/boot.js -> minispade.require('app_name/boot');
   # app/javascripts/views/main.js -> minispade.require('app_name/views/main');
   match "javascripts/**/*.js" do
-    minispade :rewrite_requires => true, :module_id_generator => proc { |input|
+    minispade :rewrite_requires => true, :string => !app.production?, :module_id_generator => proc { |input|
       input.path.gsub(/javascripts\//, "#{app.class.to_s.demodulize.underscore}/").gsub(/\.js$/, '')
     }
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -44,6 +44,30 @@ class PipelineTest < MiniTest::Unit::TestCase
     assert_includes content, %Q{minispade.register('test_app/main'}
   end
 
+  def tests_compiles_app_js_into_string_minispade_modules
+    create_file "app/javascripts/main.js", "Main = {};"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, %Q{sourceURL=test_app/main}
+  end
+
+  def tests_compiles_app_js_into_function_minispade_modules_when_in_production
+    ENV['IRIDIUM_ENV'] = 'production'
+
+    create_file "app/javascripts/main.js", "Main = {};"
+
+    compile ; assert_file "site/application.js"
+
+    content = read "site/application.js"
+
+    assert_includes content, %Q{function(){Main={}}}
+  ensure
+    ENV['IRIDIUM_ENV'] = 'test'
+  end
+
   def test_rewrites_requrires_to_use_minispade
     create_file "app/javascripts/main.js", "require('foo');"
 


### PR DESCRIPTION
... filenames in dev tools
