### PR TITLE
Update minispade to latest version

### DIFF
--- a/vendor/minispade.js
+++ b/vendor/minispade.js
@@ -1,59 +1,67 @@
 /*jshint evil:true*/
 
 if (typeof document !== "undefined") {
-  (function() {
-    minispade = {
-      root: null,
-      modules: {},
-      loaded: {},
+    (function() {
+        minispade = {
+            root: null,
+            modules: {},
+            loaded: {},
 
-      globalEval: function(data) {
-        if ( data ) {
-          // We use execScript on Internet Explorer
-          // We use an anonymous function so that context is window
-          // rather than jQuery in Firefox
-          ( window.execScript || function( data ) {
-            window[ "eval" ].call( window, data );
-          } )( data );
-        }
-      },
+            globalEval: function(data) {
+                if ( data ) {
+                    // We use execScript on Internet Explorer
+                    // We use an anonymous function so that context is window
+                    // rather than jQuery in Firefox
+                    ( window.execScript || function( data ) {
+                        window[ "eval" ].call( window, data );
+                    } )( data );
+                }
+            },
 
-      require: function(name) {
-        var loaded = minispade.loaded[name];
-        var mod = minispade.modules[name];
+            requireModule: function(name) {
+                var loaded = minispade.loaded[name];
+                var mod = minispade.modules[name];
 
-        if (!loaded) {
-          if (mod) {
-            minispade.loaded[name] = true;
+                if (!loaded) {
+                    if (mod) {
+                        minispade.loaded[name] = true;
 
-            if (typeof mod === "string") {
-              this.globalEval(mod);
-            } else {
-              mod();
+                        if (typeof mod === "string") {
+                            this.globalEval(mod);
+                        } else {
+                            mod();
+                        }
+                    } else {
+                        if (minispade.root && name.substr(0,minispade.root.length) !== minispade.root) {
+                            return minispade.requireModule(minispade.root+name);
+                        } else {
+                            throw "The module '" + name + "' could not be found";
+                        }
+                    }
+                }
+
+                return loaded;
+            },
+
+            requireAll: function(regex) {
+                for (var module in this.modules) {
+                    if (!this.modules.hasOwnProperty(module)) { continue; }
+                    if (regex && !regex.test(module)) { continue; }
+                    minispade.requireModule(module);
+                }
+            },
+
+            require: function(path) {
+                if (typeof path === 'string') {
+                    minispade.requireModule(path);
+                } else {
+                    minispade.requireAll(path);
+                }
+            },
+
+            register: function(name, callback) {
+                minispade.modules[name] = callback;
             }
-          } else {
-            if (minispade.root && name.substr(0,minispade.root.length) !== minispade.root) {
-              return minispade.require(minispade.root+name);
-            } else {
-              throw "The module '" + name + "' could not be found";
-            }
-          }
-        }
-
-        return loaded;
-      },
-
-      requireAll: function(regex) {
-        for (var module in this.modules) {
-          if (!this.modules.hasOwnProperty(module)) { continue; }
-          if (regex && !regex.test(module)) { continue; }
-          minispade.require(module);
-        }
-      },
-
-      register: function(name, callback) {
-        minispade.modules[name] = callback;
-      }
-    };
-  })();
+        };
+    })();
 }


### PR DESCRIPTION
This allows you to use a string or regex in require(path) instead of require(string) or requireAll(regex).

The example file that gets generated in app.coffee shows an example of requiring directories the same way you require individual files and that threw me for a loop:

" This file makes all the code available. Your app is initialized in the
 boot file. Here's an example

   require('jquery')
   require('ember')
   require('models')
   require('views')
   require('controllers')
   require('helpers')

 Your application begins here.."

I'm still learning minispade, but would it make sense to show an example like require(/models/) since the directory is created by default?
