### PR TITLE
Only gzip app files

### DIFF
--- a/lib/iridium/Assetfile
+++ b/lib/iridium/Assetfile
@@ -114,7 +114,7 @@ input app.root do
   manifest if app.config.pipeline.manifest
 
   if app.config.pipeline.gzip
-    match "**/*" do
+    match "**/*{.js,.css,.jpg,.png,.html}" do
       copy { |name| [name, "#{name}.gz"] }
     end
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -391,6 +391,17 @@ class PipelineTest < MiniTest::Unit::TestCase
     assert_file "site/application.js.gz"
   end
 
+  def test_gzip_ignores_project_files
+    Iridium.application.config.pipeline.gzip = true
+
+    create_file "readme.md", "This is my readme.md"
+
+    compile
+
+    refute_file "site/readme.md"
+    refute_file "site/readme.md.gz"
+  end
+
   def test_generates_a_cache_manifest
     Iridium.application.config.pipeline.manifest = true
 


### PR DESCRIPTION
When you set the gzip flag to true its copying every single file into the site directory and creating a gzipped version.  The test I think is capturing what is going wrong, but I'm pretty sure the solution is no bueno.  I'd love some feedback on a better solution.
