### PR TITLE
Exclude sass partials in subdirectories

### DIFF
--- a/lib/iridium/Assetfile
+++ b/lib/iridium/Assetfile
@@ -82,7 +82,7 @@ input app.root do
 
   # compile all SCSS files into equivalent css file.
   # SCSS partials are not included in compiled output.
-  match /app\/stylesheets\/(?:.+\/)?[^_].+\.s[ca]ss/ do
+  match /app\/stylesheets(\/(?!_)(\w+?))*\/(?!_)(\w+?)\.s[ca]ss/ do
     sass
   end
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -165,6 +165,24 @@ class PipelineTest < MiniTest::Unit::TestCase
     refute_includes content, %Q{#partial}
   end
 
+  def test_does_not_compile_sass_partials_in_sub_directory
+    create_file "app/stylesheets/partials/app.sass", <<-sass
+#this-selector
+  color: black
+    sass
+
+    create_file "app/stylesheets/_partial.sass", <<-sass
+#partial 
+  color: black
+    sass
+
+    compile ; assert_file "site/application.css"
+
+    content = read "site/application.css"
+
+    refute_includes content, %Q{#partial}
+  end
+
   def tests_compiles_handlebars_into_js_file
     create_file "app/templates/home.handlebars", "{{name}}"
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -166,12 +166,12 @@ class PipelineTest < MiniTest::Unit::TestCase
   end
 
   def test_does_not_compile_sass_partials_in_sub_directory
-    create_file "app/stylesheets/partials/app.sass", <<-sass
+    create_file "app/stylesheets/app.sass", <<-sass
 #this-selector
   color: black
     sass
 
-    create_file "app/stylesheets/_partial.sass", <<-sass
+    create_file "app/stylesheets/partials/_partial.sass", <<-sass
 #partial 
   color: black
     sass


### PR DESCRIPTION
Presently only SASS partials in the root directory of **app/stylesheets** are being excluded from compilation.

I've updated the regex in AssetFile to exclude sass partials in subdirectories, e.g.

> /app/stylesheets/partials/_partial.scss

I've addeed a test to pipeline_test named **test_does_not_compile_sass_partials_in_sub_directory** to confirm the change.
