### PR TITLE
fetching deps on tubygems, not on gihub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ First create a `Gemfile`
 source :rubygems
 
 gem 'iridium', :github => 'radiumsoftware/iridium'
-gem "rake-pipeline", :github => "livingsocial/rake-pipeline"
-gem "rake-pipeline-web-filters", :github => "wycats/rake-pipeline-web-filters"
+gem "rake-pipeline"
+gem "rake-pipeline-web-filters"
 ```
 
 Now bootstrap:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ First create a `Gemfile`
 source :rubygems
 
 gem 'iridium', :github => 'radiumsoftware/iridium'
-gem "rake-pipeline"
-gem "rake-pipeline-web-filters"
+
 ```
 
 Now bootstrap:


### PR DESCRIPTION
rake-pipeline and rake-pipeline-filters fetched on github are in version 0.6, iridium requires 0.7
