### PR TITLE
Fix #32: Running iridium compile with default config/production.rb fails

### DIFF
--- a/generators/iridium/application/templates/config/production.rb.tt
+++ b/generators/iridium/application/templates/config/production.rb.tt
@@ -10,7 +10,7 @@
 
   # Run templates through a precompiler instead of using
   # compile and runtime mode.
-  config.handlebars.compiler = Iridium::Pipeline::HandlebarsPrecompiler
+  config.handlebars.compiler = Iridium::Pipeline::HandlebarsFilePrecompiler
 
   # Run javascript code through this inline precompiler
   config.handlebars.inline_compiler = Iridium::Pipeline::InlinePrecompilerFilter


### PR DESCRIPTION
When running `bundle exec iridium compile` I'm getting the following exception.

```
/Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-pipeline-web-filters-0.7.0/lib/rake-pipeline-web-filters/handlebars_filter.rb:52:in `block in generate_output': undefined method `call' for Iridium::Pipeline::HandlebarsPrecompiler:Class (NoMethodError)
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-pipeline-web-filters-0.7.0/lib/rake-pipeline-web-filters/handlebars_filter.rb:44:in `each'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-pipeline-web-filters-0.7.0/lib/rake-pipeline-web-filters/handlebars_filter.rb:44:in `generate_output'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/filter.rb:218:in `block (3 levels) in generate_rake_tasks'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/file_wrapper.rb:135:in `create'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/filter.rb:218:in `block (2 levels) in generate_rake_tasks'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:227:in `call'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:227:in `block in execute'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:222:in `each'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:222:in `execute'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:166:in `block in invoke_with_call_chain'
    from /Users/stephan/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:159:in `invoke_with_call_chain'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/dynamic_file_task.rb:154:in `invoke_with_call_chain'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/gems/rake-0.9.5/lib/rake/task.rb:152:in `invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/dynamic_file_task.rb:60:in `invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline.rb:328:in `block (2 levels) in invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline.rb:328:in `each'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline.rb:328:in `block in invoke'
    from <internal:prelude>:10:in `synchronize'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline.rb:321:in `invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/project.rb:126:in `each'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/project.rb:126:in `block in invoke'
    from <internal:prelude>:10:in `synchronize'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/rake-pipeline-ae0795842a89/lib/rake-pipeline/project.rb:112:in `invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/iridium-c0c8e6fd5a23/lib/iridium/pipeline.rb:52:in `block in compile'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/iridium-c0c8e6fd5a23/lib/iridium/pipeline.rb:51:in `chdir'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/iridium-c0c8e6fd5a23/lib/iridium/pipeline.rb:51:in `compile'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/iridium-c0c8e6fd5a23/lib/iridium/pipeline/compile_command.rb:11:in `compile'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/task.rb:27:in `run'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor.rb:344:in `dispatch'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/invocation.rb:109:in `invoke'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor.rb:214:in `block in subcommand'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/task.rb:27:in `run'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/invocation.rb:120:in `invoke_task'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor.rb:344:in `dispatch'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/thor-15eedc90f499/lib/thor/base.rb:434:in `start'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/iridium-c0c8e6fd5a23/bin/iridium:4:in `<top (required)>'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bin/iridium:23:in `load'
    from /Users/stephan/.rvm/gems/ruby-1.9.3-p194/bin/iridium:23:in `<main>'
```
