### PR TITLE
Add --port option for 'iridium server' command

### DIFF
--- a/lib/iridium/rack/dev_server.rb
+++ b/lib/iridium/rack/dev_server.rb
@@ -24,7 +24,7 @@ module Iridium
 
       # Override the call to options so ARV isn't parsed
       def options
-        {}
+        @options || {}
       end
 
       def app

--- a/lib/iridium/rack/server_command.rb
+++ b/lib/iridium/rack/server_command.rb
@@ -5,12 +5,13 @@ module Iridium
 
       desc "server", "start a development server"
       method_option :environment, :aliases => '-e', :default => 'development'
+      method_option :port, :aliases => '-p', :default => '8080'
       def server
         ENV['IRIDIUM_ENV'] = options[:environment]
 
         Iridium.load!
         Iridium.application.clean!
-        Iridium::Rack::DevServer.new.start
+        Iridium::Rack::DevServer.new(Port: options[:port]).start
       end
 
       default_task :server


### PR DESCRIPTION
Allow to specify a port when starting the development server, similar to how the rackup command handles it. Another option would be to require the user to use the iridium generate rackup command and run the server that way, but having a command line option available directly looks more convenient to me.
`bundle exec iridium server -p 9090`
