### PR TITLE
Load the bundled dependencies if we want to run the iridium command from the git repo

### DIFF
--- a/bin/iridium
+++ b/bin/iridium
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 
+if File.exists?(File.join(File.expand_path('../../', __FILE__), '.git'))
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+  require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+end
+
 require 'iridium'
 
 local_iridium_app = "#{Dir.pwd}/application.rb"

--- a/bin/iridium
+++ b/bin/iridium
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'iridium'
+
+local_iridium_app = "#{Dir.pwd}/application.rb"
+require local_iridium_app if File.exists? local_iridium_app
+
 require 'iridium/cli'
 
 Iridium::CLI.start

--- a/bin/iridium
+++ b/bin/iridium
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'iridium'
+require 'iridium/cli'
+
 Iridium::CLI.start

--- a/lib/iridium.rb
+++ b/lib/iridium.rb
@@ -93,4 +93,3 @@ require 'iridium/jslint'
 require 'iridium/application'
 
 require 'iridium/generators'
-require 'iridium/cli'

--- a/test/integration/new_app_test.rb
+++ b/test/integration/new_app_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'iridium/cli'
 
 # NOTE: Make sure each generated app is unique so it can be required
 # and the inherited callback will hit. This makes things work as expected


### PR DESCRIPTION
Use case: I want to play with the edge version of iridium, which i have cloned in ~/src/iridium.

Running this
  $ ~/src/iridium/bin/iridium generate app my_app
did not work, because iridium could not find its dependencies. This fixes that.

Inspired by rails/railties/bin/rails
