### PR TITLE
Upgrading handlebars source

### DIFF
--- a/iridium.gemspec
+++ b/iridium.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport"
   gem.add_dependency "thor"
   gem.add_dependency "barber", "~> 0.4.2"
-  gem.add_dependency "handlebars-source", "1.0.0rc3"
+  gem.add_dependency "handlebars-source", "1.0.12"
   gem.add_dependency "grit"
 
   gem.add_development_dependency "simplecov"


### PR DESCRIPTION
iridium-ember was complaining of handlebars-source version conflict which was occurring between ember-source and iridium

1.0.0rc3 vs 1.0.12
